### PR TITLE
added bracketing 3 images, max diff

### DIFF
--- a/app/src/main/java/com/jonasjuffinger/timelapse/Settings.java
+++ b/app/src/main/java/com/jonasjuffinger/timelapse/Settings.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static android.preference.PreferenceManager.getDefaultSharedPreferences;
 
 /**
@@ -16,6 +18,7 @@ class Settings {
     private static final String EXTRA_DISPLAYOFF = "com.jonasjuffinger.timelapse.DISPLAYOFF";
     private static final String EXTRA_SILENTSHUTTER = "com.jonasjuffinger.timelapse.SILENTSHUTTER";
     private static final String EXTRA_AEL = "com.jonasjuffinger.timelapse.AEL";
+    private static final String EXTRA_BRS = "com.jonasjuffinger.timelapse.BRS";
 
     int interval, rawInterval;
     int shotCount, rawShotCount;
@@ -23,6 +26,7 @@ class Settings {
     boolean silentShutter;
     boolean ael;
     int fps;    // index
+    boolean brs;
 
     Settings() {
         interval = 1;
@@ -33,14 +37,16 @@ class Settings {
         silentShutter = true;
         ael = true;
         fps = 0;
+        brs = true;
     }
 
-    public Settings(int interval, int shotCount, boolean displayOff, boolean silentShutter, boolean ael) {
+    public Settings(int interval, int shotCount, boolean displayOff, boolean silentShutter, boolean ael, boolean brs) {
         this.interval = interval;
         this.shotCount = shotCount;
         this.displayOff = displayOff;
         this.silentShutter = silentShutter;
         this.ael = ael;
+        this.brs = brs;
     }
 
     void putInIntent(Intent intent) {
@@ -49,6 +55,7 @@ class Settings {
         intent.putExtra(EXTRA_DISPLAYOFF, displayOff);
         intent.putExtra(EXTRA_SILENTSHUTTER, silentShutter);
         intent.putExtra(EXTRA_AEL, ael);
+        intent.putExtra(EXTRA_BRS, brs);
     }
 
     static Settings getFromIntent(Intent intent) {
@@ -57,7 +64,8 @@ class Settings {
                 intent.getIntExtra(EXTRA_SHOTCOUNT, 1),
                 intent.getBooleanExtra(EXTRA_DISPLAYOFF, false),
                 intent.getBooleanExtra(EXTRA_SILENTSHUTTER, false),
-                intent.getBooleanExtra(EXTRA_AEL, false)
+                intent.getBooleanExtra(EXTRA_AEL, false),
+                intent.getBooleanExtra(EXTRA_BRS, false)
         );
     }
 
@@ -70,6 +78,7 @@ class Settings {
         editor.putBoolean("silentShutter", silentShutter);
         editor.putBoolean("ael", ael);
         editor.putInt("fps", fps);
+        editor.putBoolean("brs", brs);
         editor.apply();
     }
 
@@ -81,5 +90,6 @@ class Settings {
         silentShutter = sharedPref.getBoolean("silentShutter", silentShutter);
         ael = sharedPref.getBoolean("ael", ael);
         fps = sharedPref.getInt("fps", fps);
+        brs = sharedPref.getBoolean("brs", brs);
     }
 }

--- a/app/src/main/java/com/jonasjuffinger/timelapse/SettingsActivity.java
+++ b/app/src/main/java/com/jonasjuffinger/timelapse/SettingsActivity.java
@@ -39,6 +39,7 @@ public class SettingsActivity extends BaseActivity
 
     private CheckBox cbSilentShutter;
     private CheckBox cbAEL;
+    private CheckBox cbBRS;
 
     @Override
     protected void onCreate(Bundle savedInstanceState)
@@ -72,8 +73,10 @@ public class SettingsActivity extends BaseActivity
         tvShotsValue = (TextView) findViewById(R.id.tvShotsValue);
         sbShots = (AdvancedSeekBar) findViewById(R.id.sbShots);
         spnFps = (Spinner) findViewById(R.id.spnFps);
+
         cbSilentShutter = (CheckBox) findViewById(R.id.cbSilentShutter);
         cbAEL = (CheckBox) findViewById(R.id.cbAEL);
+        cbBRS = (CheckBox) findViewById(R.id.cbBRC);
 
         sbInterval.setMax(83);
         sbInterval.setOnSeekBarChangeListener(sbIntervalOnSeekBarChangeListener);
@@ -92,6 +95,9 @@ public class SettingsActivity extends BaseActivity
 
         cbAEL.setChecked(settings.ael);
         cbAEL.setOnCheckedChangeListener(cbAELOnCheckListener);
+
+        cbBRS.setChecked(settings.brs);
+        cbBRS.setOnCheckedChangeListener(cbBRSOnCheckListener);
 
         //try {
             //CameraEx cameraEx = CameraEx.open(0, null);
@@ -223,6 +229,13 @@ public class SettingsActivity extends BaseActivity
         @Override
         public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
             settings.ael = b;
+        }
+    };
+
+    CheckBox.OnCheckedChangeListener cbBRSOnCheckListener = new CheckBox.OnCheckedChangeListener() {
+        @Override
+        public void onCheckedChanged(CompoundButton compoundButton, boolean b) {
+            settings.brs = b;
         }
     };
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -186,6 +186,16 @@
                     android:checked="true"
                     android:layout_toRightOf="@id/cbSilentShutter"
                     android:text="AEL" />
+
+            <CheckBox
+                    android:id="@+id/cbBRC"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentTop="true"
+                    android:layout_marginLeft="10dp"
+                    android:checked="true"
+                    android:layout_toRightOf="@id/cbAEL"
+                    android:text="BRC3" />
         </RelativeLayout>
     </LinearLayout>
 


### PR DESCRIPTION
this one adds one more check-box to activate bracketing 3 images, max difference between expositions. Probably will be useful to someone that wants to make HDR. it takes 3 images one after other. Tried for me in Aperature priority - works ok. Just make sure to have higher time diff between shots, since for me in dark conditions I put 10seconds, and it takes 5 seconds to make 3 shots and waits only 5seconds to take next 3 (instead 10).