### PR TITLE
Feature: Optionally wait for initial delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Thanks to [ma1co](https://github.com/ma1co) for creating this amazing framework 
 ## Usage ##
 The app is easy to use. It doesn't have any controls for shutter speed, aperture, ISO, picture quality etc. Adjust all this settings before starting the app, it will use them. If you don't want the camera to focus before each shot, set the camera to manual mode.
 
-Then start the app set the shoot interval and the amount of pictures it should take. Below the seek bars you can see how long it will take to shoot all the photos and how long the video will be. The fps setting only changes the calculation of the video length, the app doesn't produce a video.
+Then start the app set the shoot interval and the amount of pictures it should take. The delay slider can be used to delay the start of the timelapse recording (set to zero to start immediately). Below the seek bars you can see how long it will take to shoot all the photos and how long the video will be. The fps setting only changes the calculation of the video length, the app doesn't produce a video.
 
 Finally click the start button and wait.
 

--- a/app/src/main/java/com/jonasjuffinger/timelapse/Settings.java
+++ b/app/src/main/java/com/jonasjuffinger/timelapse/Settings.java
@@ -13,6 +13,7 @@ import static android.preference.PreferenceManager.getDefaultSharedPreferences;
  */
 
 class Settings {
+    private static final String EXTRA_DELAY = "com.jonasjuffinger.timelapse.DELAY";
     private static final String EXTRA_INTERVAL = "com.jonasjuffinger.timelapse.INTERVAL";
     private static final String EXTRA_SHOTCOUNT = "com.jonasjuffinger.timelapse.SHOTCOUNT";
     private static final String EXTRA_DISPLAYOFF = "com.jonasjuffinger.timelapse.DISPLAYOFF";
@@ -20,6 +21,7 @@ class Settings {
     private static final String EXTRA_AEL = "com.jonasjuffinger.timelapse.AEL";
     private static final String EXTRA_BRS = "com.jonasjuffinger.timelapse.BRS";
 
+    int delay, rawDelay;
     double interval;
     int rawInterval;
     int shotCount, rawShotCount;
@@ -30,6 +32,8 @@ class Settings {
     boolean brs;
 
     Settings() {
+        delay = 0;
+        rawDelay = 0;
         interval = 1;
         rawInterval = 1;
         shotCount = 1;
@@ -41,7 +45,8 @@ class Settings {
         brs = true;
     }
 
-    public Settings(double interval, int shotCount, boolean displayOff, boolean silentShutter, boolean ael, boolean brs) {
+    public Settings(int delay, double interval, int shotCount, boolean displayOff, boolean silentShutter, boolean ael, boolean brs) {
+        this.delay = delay;
         this.interval = interval;
         this.shotCount = shotCount;
         this.displayOff = displayOff;
@@ -51,6 +56,7 @@ class Settings {
     }
 
     void putInIntent(Intent intent) {
+        intent.putExtra(EXTRA_DELAY, delay);
         intent.putExtra(EXTRA_INTERVAL, interval);
         intent.putExtra(EXTRA_SHOTCOUNT, shotCount);
         intent.putExtra(EXTRA_DISPLAYOFF, displayOff);
@@ -61,6 +67,7 @@ class Settings {
 
     static Settings getFromIntent(Intent intent) {
         return new Settings(
+                intent.getIntExtra(EXTRA_DELAY, 0),
                 intent.getDoubleExtra(EXTRA_INTERVAL, 1),
                 intent.getIntExtra(EXTRA_SHOTCOUNT, 1),
                 intent.getBooleanExtra(EXTRA_DISPLAYOFF, false),
@@ -74,6 +81,7 @@ class Settings {
     {
         SharedPreferences sharedPref = getDefaultSharedPreferences(context);
         SharedPreferences.Editor editor = sharedPref.edit();
+        editor.putInt("delay", rawDelay);
         editor.putInt("interval", rawInterval);
         editor.putInt("shotCount", rawShotCount);
         editor.putBoolean("silentShutter", silentShutter);
@@ -86,6 +94,7 @@ class Settings {
     void load(Context context)
     {
         SharedPreferences sharedPref = getDefaultSharedPreferences(context);
+        rawDelay = sharedPref.getInt("delay", rawDelay);
         rawInterval = sharedPref.getInt("interval", rawInterval);
         rawShotCount = sharedPref.getInt("shotCount", rawShotCount);
         silentShutter = sharedPref.getBoolean("silentShutter", silentShutter);

--- a/app/src/main/java/com/jonasjuffinger/timelapse/SettingsActivity.java
+++ b/app/src/main/java/com/jonasjuffinger/timelapse/SettingsActivity.java
@@ -27,6 +27,9 @@ public class SettingsActivity extends BaseActivity
 
     private Button bnStart, bnClose;
 
+    private AdvancedSeekBar sbDelay;
+    private TextView tvDelayValue, tvDelayUnit;
+
     private AdvancedSeekBar sbInterval;
     private TextView tvIntervalValue, tvIntervalUnit;
 
@@ -68,10 +71,14 @@ public class SettingsActivity extends BaseActivity
         tvIntervalValue = (TextView) findViewById(R.id.tvIntervalValue);
         tvIntervalUnit = (TextView) findViewById(R.id.tvIntervalUnit);
 
+        tvDelayValue = (TextView) findViewById(R.id.tvDelayValue);
+        tvDelayUnit = (TextView) findViewById(R.id.tvDelayUnit);
+
         tvDurationValue = (TextView) findViewById(R.id.tvDurationValue);
         tvDurationUnit = (TextView) findViewById(R.id.tvDurationUnit);
         tvVideoTimeValue = (TextView) findViewById(R.id.tvVideoTimeValue);
         tvVideoTimeUnit = (TextView) findViewById(R.id.tvVideoTimeUnit);
+        sbDelay = (AdvancedSeekBar) findViewById((R.id.sbDelay));
         sbInterval = (AdvancedSeekBar) findViewById(R.id.sbInterval);
         tvShotsValue = (TextView) findViewById(R.id.tvShotsValue);
         sbShots = (AdvancedSeekBar) findViewById(R.id.sbShots);
@@ -81,6 +88,11 @@ public class SettingsActivity extends BaseActivity
         cbSilentShutter = (CheckBox) findViewById(R.id.cbSilentShutter);
         cbAEL = (CheckBox) findViewById(R.id.cbAEL);
         cbBRS = (CheckBox) findViewById(R.id.cbBRC);
+
+        sbDelay.setMax(59*5 + 2);
+        sbDelay.setOnSeekBarChangeListener(sbDelayOnSeekBarChangeListener);
+        sbDelay.setProgress(settings.rawDelay);
+        sbDelayOnSeekBarChangeListener.onProgressChanged(sbDelay, settings.rawDelay, false);
 
         sbInterval.setMax(119);
         sbInterval.setOnSeekBarChangeListener(sbIntervalOnSeekBarChangeListener);
@@ -190,6 +202,41 @@ public class SettingsActivity extends BaseActivity
         @Override
         public void onStopTrackingTouch(SeekBar seekBar) {}
     },
+
+    sbDelayOnSeekBarChangeListener = new SeekBar.OnSeekBarChangeListener() {
+        @Override
+        public void onProgressChanged(SeekBar seekBar, int i, boolean b) {
+            String delayTextValue = "";
+            String delayUnit = "";
+
+            if(i <= 59) {
+                settings.rawDelay = i;
+                settings.delay = i * 1000;
+                delayTextValue = Integer.toString(settings.rawDelay);
+                delayUnit = "s";
+            }else if(i <= 59+179) {
+                settings.rawDelay = i - 59;
+                settings.delay = settings.rawDelay * 60 * 1000;
+                delayTextValue = Integer.toString(settings.rawDelay);
+                delayUnit = "m";
+            }else if(i > 59+179) {
+                settings.rawDelay = i - 59-180 + 2;
+                settings.delay = settings.rawDelay * 60 * 60 * 1000;
+                delayTextValue = Integer.toString(settings.rawDelay);
+                delayUnit = "h";
+            }
+
+            tvDelayValue.setText(delayTextValue);
+            tvDelayUnit.setText(delayUnit);
+        }
+
+        @Override
+        public void onStartTrackingTouch(SeekBar seekBar) { }
+
+        @Override
+        public void onStopTrackingTouch(SeekBar seekBar) {}
+    },
+
     sbShotsOnSeekBarChangeListener = new SeekBar.OnSeekBarChangeListener() {
         @Override
         public void onProgressChanged(SeekBar seekBar, int i, boolean fromUser) {
@@ -311,24 +358,28 @@ public class SettingsActivity extends BaseActivity
     }
 
     protected boolean onUpperDialChanged(int value) {
+        sbDelay.dialChanged(value);
         sbInterval.dialChanged(value);
         sbShots.dialChanged(value);
         return true;
     }
 
     protected boolean onLowerDialChanged(int value) {
+        sbDelay.dialChanged(value);
         sbInterval.dialChanged(value);
         sbShots.dialChanged(value);
         return true;
     }
 
     protected boolean onThirdDialChanged(int value) {
+        sbDelay.dialChanged(value);
         sbInterval.dialChanged(value);
         sbShots.dialChanged(value);
         return true;
     }
 
     protected boolean onKuruDialChanged(int value) {
+        sbDelay.dialChanged(value);
         sbInterval.dialChanged(value);
         sbShots.dialChanged(value);
         return true;

--- a/app/src/main/java/com/jonasjuffinger/timelapse/ShootActivity.java
+++ b/app/src/main/java/com/jonasjuffinger/timelapse/ShootActivity.java
@@ -40,6 +40,7 @@ public class ShootActivity extends BaseActivity implements SurfaceHolder.Callbac
     private boolean stopPicturePreview;
     private boolean takingPicture;
 
+    private long delayUntilTime;
     private long shootTime;
 
     private Display display;
@@ -66,7 +67,23 @@ public class ShootActivity extends BaseActivity implements SurfaceHolder.Callbac
                 //display.off();
             }
 
-            if(shotCount < settings.shotCount * getcnt()) {
+            if(System.currentTimeMillis() < delayUntilTime) {
+
+                long secondsRemaining = ((delayUntilTime - System.currentTimeMillis()) / 1000);
+                int hours = (int) secondsRemaining / 3600;
+                int remainder = (int) secondsRemaining - hours * 3600;
+                int minutes = remainder / 60;
+                remainder = remainder - minutes * 60;
+                int seconds = remainder;
+
+                tvRemaining.setVisibility(View.INVISIBLE);
+                tvCount.setText("Delay: " + hours + "h " + minutes + "m " + seconds + "s");
+
+                shootRunnableHandler.postDelayed(this, 1000);
+
+            } else if(shotCount < settings.shotCount * getcnt()) {
+                tvRemaining.setVisibility(View.VISIBLE);
+
                 long remainingTime = Math.round(shootTime + settings.interval * 1000 - System.currentTimeMillis());
                 if(brck.get()>0){
                     remainingTime = -1;
@@ -181,6 +198,7 @@ public class ShootActivity extends BaseActivity implements SurfaceHolder.Callbac
         pictureReviewTime = autoReviewControl.getPictureReviewTime();
         log(Integer.toString(pictureReviewTime));
 
+        delayUntilTime = System.currentTimeMillis() + settings.delay;
 
         shootRunnableHandler.postDelayed(shootRunnable, 1000);
 

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -19,6 +19,54 @@
             android:orientation="horizontal">
 
             <TextView
+                android:id="@+id/lblDelay"
+                android:layout_width="80dp"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="10dp"
+                android:gravity="center_vertical"
+                android:text="Delay"
+                android:textSize="20sp" />
+
+            <view
+                android:id="@+id/sbDelay"
+                class="com.jonasjuffinger.timelapse.AdvancedSeekBar"
+                android:layout_width="240dp"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_marginRight="10dp"
+                android:layout_toLeftOf="@+id/tvDelayValue"
+                android:layout_toRightOf="@+id/lblDelay"
+                android:gravity="center_vertical" />
+
+            <TextView
+                android:id="@+id/tvDelayUnit"
+                android:layout_width="40dp"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_alignParentRight="true"
+                android:gravity="center_vertical"
+                android:text="sec"
+                android:textSize="20sp" />
+
+            <TextView
+                android:id="@+id/tvDelayValue"
+                android:layout_width="40dp"
+                android:layout_height="wrap_content"
+                android:layout_alignParentTop="true"
+                android:layout_marginRight="5dp"
+                android:layout_toLeftOf="@+id/tvDelayUnit"
+                android:gravity="right|center_vertical"
+                android:text="10.5"
+                android:textSize="20sp" />
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="10dp"
+            android:orientation="horizontal">
+
+            <TextView
                 android:id="@+id/lblInterval"
                 android:layout_width="80dp"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
Hey! 

Thanks for the great work on this app!

I wanted to record a timelapse of wild animals early in the morning and needed a way to automatically start the timelapse at a given time. The quickest solution I came up with was to add a delay feature to your app, to allow the user to select a delay before the timelapse recording begins.

The additions to the UI are: 
* SettingsActivity: A delay slider using the same AdvancedSeekBar
* ShootActivity: Re-purposing an existing TextView to show the delay countdown

I've tested the app successfully on my a6500 (and yes, I did capture some animals in the timelapse :)

I tried to follow your UI design and code structure to make the change possible to merge, in case you find it useful. 

Best regards,
Jonathan